### PR TITLE
Active la compression sur le html, le css, le js et les exports (et corrige le filtre KML)

### DIFF
--- a/htaccess.modele.txt
+++ b/htaccess.modele.txt
@@ -60,9 +60,12 @@ RewriteRule . ./index.php [L]
 </ifmodule>
 
 #On demande la compression gzip des contenu suivants, ça gagnent vraiment de la bande passante sur les json (l'api) les xml (parfois) et l'export kml
+#On compresse aussi le html, le css, le js et les svg : ce sont des formats texte très compressibles (-72% mesuré)
+#et ça change tout pour les visiteurs en 3G/Edge depuis la montagne. Le gros morceau est myol.js : 726 Ko -> 206 Ko
 <IfModule mod_deflate.c>
   <IfModule mod_filter.c>
     AddOutputFilterByType DEFLATE application/rss+xml application/xml application/json application/vnd.google-earth
+    AddOutputFilterByType DEFLATE text/html text/css text/javascript application/javascript image/svg+xml
   </IfModule>
 </IfModule>
 

--- a/htaccess.modele.txt
+++ b/htaccess.modele.txt
@@ -64,7 +64,8 @@ RewriteRule . ./index.php [L]
 #et ça change tout pour les visiteurs en 3G/Edge depuis la montagne. Le gros morceau est myol.js : 726 Ko -> 206 Ko
 <IfModule mod_deflate.c>
   <IfModule mod_filter.c>
-    AddOutputFilterByType DEFLATE application/rss+xml application/xml application/json application/vnd.google-earth
+    #Le KML sort en "application/vnd.google-earth.kml" : sans le ".kml" la directive ne matchait rien
+    AddOutputFilterByType DEFLATE application/rss+xml application/xml application/json application/vnd.google-earth.kml
     AddOutputFilterByType DEFLATE text/html text/css text/javascript application/javascript image/svg+xml
     #Les exports : GPX (3 vues), GML (sort en text/xml et pas application/xml) et CSV
     AddOutputFilterByType DEFLATE application/gpx+xml text/xml text/csv

--- a/htaccess.modele.txt
+++ b/htaccess.modele.txt
@@ -66,6 +66,8 @@ RewriteRule . ./index.php [L]
   <IfModule mod_filter.c>
     AddOutputFilterByType DEFLATE application/rss+xml application/xml application/json application/vnd.google-earth
     AddOutputFilterByType DEFLATE text/html text/css text/javascript application/javascript image/svg+xml
+    #Les exports : GPX (3 vues), GML (sort en text/xml et pas application/xml) et CSV
+    AddOutputFilterByType DEFLATE application/gpx+xml text/xml text/csv
   </IfModule>
 </IfModule>
 


### PR DESCRIPTION
Bonjour ! Trois commits sur `htaccess.modele.txt`, autour de `mod_deflate`. Le troisième corrige un filtre qui n'a, sauf erreur, jamais eu d'effet.

## Le problème

`AddOutputFilterByType` exige une correspondance MIME **exacte**. Or plusieurs types envoyés par le site ne sont pas dans la liste :

| Format | Content-Type envoyé | Couvert ? |
|---|---|---|
| KML | `application/vnd.google-earth.kml` | ❌ la directive dit `application/vnd.google-earth`, sans le `.kml` |
| GPX | `application/gpx+xml` | ❌ |
| GML | `text/xml` | ❌ `application/xml` ne le couvre pas |
| CSV | `text/csv` | ❌ |

Et le html, le css et le js ne sont pas compressés du tout, alors que ce sont les formats les plus compressibles du site.

Le cas KML est le plus embêtant : c'est le format le plus verbeux, il était visé intentionnellement, et le `.kml` manquant fait que le filtre ne matche rien.

## Les 3 commits

1. `text/html` `text/css` `text/javascript` `application/javascript` `image/svg+xml`
2. `application/gpx+xml` `text/xml` `text/csv` — les exports
3. `application/vnd.google-earth` → `application/vnd.google-earth.kml`

Votre ligne d'origine est conservée, les nouveaux types sont sur des lignes séparées.

## Gains

Sur des données réelles de production (`bbox=5.0,44.0,7.5,46.5`, 3 678 points, `detail=complet`) :

| | avant | après |
|---|---|---|
| export KML | 5,5 Mo | 1,1 Mo (−81 %) |
| export GPX | 3,3 Mo | 940 Ko (−72 %) |
| `myol.js` | 726 Ko | 207 Ko (−72 %) |

Lighthouse mobile Slow 4G sur `/nav` : score 80 → 100, LCP 5,4 s → 1,1 s.

C'est surtout l'usage en montagne qui y gagne : récupérer une trace avant de partir, c'est le moment où la bande passante est comptée. Rien ne change visuellement, le contenu décompressé est identique octet pour octet.

## Deux points d'attention

**BREACH.** Compresser `text/html` sur HTTPS réunit les conditions de l'attaque quand une page contient un secret et une entrée reflétée — ici `bandeau.html` porte le `form_token` phpBB et reflète `REQUEST_URI`. À mon avis le risque est faible (jeton de formulaire à durée de vie courte, pas un cookie de session, et la plupart des sites font pareil), mais ça me semble être votre décision. Si vous préférez, retirer `text/html` conserve l'essentiel du gain.

**Déploiement.** `.htaccess` étant gitignoré, merger ne changera rien à la prod : il faut aussi reporter les lignes dans le `.htaccess` du serveur.

```bash
curl -sI -H "Accept-Encoding: gzip" https://www.refuges.info/myol/dist/myol.js | grep -i content-encoding
```

Vérifié : 7 routes html et 8 formats d'export répondent à l'identique, `Vary: Accept-Encoding` bien émis, pas de double compression (`zlib.output_compression` off).