### PR TITLE
Ouvre les menus du bandeau quand on y arrive au clavier

### DIFF
--- a/vues/bandeau.css
+++ b/vues/bandeau.css
@@ -59,11 +59,17 @@ body {
 }
 
 /* Ligne de menus */
+/* :focus-within => le menu s'ouvre aussi quand on y arrive au clavier.
+   Sans ça, les liens restaient dans l'ordre de tabulation mais en opacity:0,
+   donc invisibles : on traversait 18 éléments fantômes avant le contenu. */
 .menu-touch:not(.menu-liste)>ul,
 .menu-hover:not(.menu-liste)>ul,
+.menu-bouton:focus-within:not(.menu-liste)>ul,
 .menu-touch:not(.menu-liste)>form,
 .menu-hover:not(.menu-liste)>form,
+.menu-bouton:focus-within:not(.menu-liste)>form,
 .menu-hover:not(.menu-liste)>p,
+.menu-bouton:focus-within:not(.menu-liste)>p,
 .menu-hover:not(.menu-liste)>a {
   opacity: 1;
   z-index: 2000;
@@ -83,7 +89,8 @@ body {
 }
 
 .menu-touch:not(.menu-liste) li,
-.menu-hover:not(.menu-liste) li {
+.menu-hover:not(.menu-liste) li,
+.menu-bouton:focus-within:not(.menu-liste) li {
   /* Pour transition */
   max-height: 2.2em;
 }


### PR DESCRIPTION
Bonjour ! Un correctif d'accessibilité en 8 lignes de CSS, sur `vues/bandeau.css`.

## Le problème

Les blocs rétractables du bandeau sont masqués par `opacity: 0` + `z-index: -2000` (l. 46-48), et non par `display: none`. Leurs liens **restent donc dans l'ordre de tabulation tout en étant invisibles**. Et l'ouverture ne se déclenche que sur `mouseover` / `click` (`bandeau.js`), sans équivalent au clavier.

Concrètement, en tabulant depuis le haut d'une page, on traverse **18 éléments qu'on ne voit pas** (« Accueil », « Qui sommes nous ? », « Donation », … « Mentions légales ») avant d'atteindre le contenu — et il n'y a aucun moyen d'ouvrir un menu sans souris.

## Le correctif

`:focus-within` ajouté à côté de vos `.menu-hover` / `.menu-touch`, dans les deux blocs concernés :

- l'opacité et le `z-index` du conteneur (`>ul`, `>form`, `>p`)
- le `max-height` des `li` — sans ça le menu s'ouvre mais reste vide

## Résultat

Sur une fiche de point, nombre de tabulations aboutissant sur un élément invisible : **19 → 0**.

## Vérifié

- pas d'ouverture parasite quand le focus est ailleurs dans la page, et fermeture au blur
- **survol souris et bascule au clic inchangés**, desktop et mobile
- axe-core : nombre de nœuds identique avant/après sur l'accueil, une fiche et `/nav`

Petite remarque au passage : axe-core **ne détecte pas** ce défaut, parce qu'un élément en `opacity: 0` reste dans l'arbre d'accessibilité. Le chiffre ci-dessus vient d'une sonde clavier maison qui calcule l'opacité effective en multipliant celle de tous les ancêtres.

Critères RGAA concernés : 10.7 (focus visible), 12.8 (ordre de tabulation cohérent), 7.3 (contrôlable au clavier).