### PR TITLE
Donne un titre à la page d'ajout de commentaire

### DIFF
--- a/controlleurs/point_ajout_commentaire.php
+++ b/controlleurs/point_ajout_commentaire.php
@@ -109,7 +109,7 @@ if (empty($point->erreur))
       else
       {
         $vue->type = "page_simple";
-        $vue->contenu="Impossible d'ajouter ce commentaire car : ".$commentaire->message;
+        $vue->contenu=$vue->titre="Impossible d'ajouter ce commentaire car : ".$commentaire->message;
         return;
       }
 
@@ -121,6 +121,8 @@ if (empty($point->erreur))
 
   // Qu'on arrive juste ou que l'on vienne déjà de rentrer un premier commentaire, on affiche le formulaire (rappel paramètres si erreur, vide si nouveau commentaire de +)
   $vue->nom_point=protege($point->nom);
+  // Le titre n'était défini que dans les branches d'erreur : la page nominale sortait avec un <title> vide
+  $vue->titre="Ajouter une information ou une photo sur $vue->nom_point";
   $vue->lien_point=lien_point($point);
   $vue->point_existe=True;
   $vue->commentaire=$commentaire;


### PR DESCRIPTION
Bonjour ! Un petit oubli dans `controlleurs/point_ajout_commentaire.php`.

## Le problème

`$vue->titre` n'est affecté que dans les branches d'erreur. Sur le chemin nominal, la page sort donc avec `<title></title>`.

C'est visible en prod aujourd'hui :

```bash
$ curl -s https://www.refuges.info/point_ajout_commentaire/7885 | grep -o "<title>[^<]*</title>"
<title></title>
```

Amusant : sur un point **inexistant** le titre est correct (la branche 404 le renseigne), sur un point **valide** il est vide. Le titre n'apparaît que quand la page échoue.

## Le correctif

Deux chemins étaient concernés :

- **page nominale** → `« Ajouter une information ou une photo sur <nom du point> »`, formulé d'après le lien qui y mène depuis la fiche. J'utilise `$vue->nom_point`, déjà échappé par `protege()` juste au-dessus, `<title>` étant un contexte HTML.
- **erreur de soumission** (l. 111) → `$vue->contenu=$vue->titre=…`, en reprenant l'idiome déjà utilisé dans `nav.php`, `nouvelles.php` et `page_simple.php`.

Dites-moi si vous préférez une autre formulation pour le titre, c'est vous qui connaissez le ton du site.

## Vérifié

- page nominale, mode `?correction=oui` et point inexistant : titres corrects
- point dont le nom contient une apostrophe (« Refuge du Pas de l'Aiguille ») : échappé en `&#039;` et restitué correctement par le navigateur
- balayage des principales routes : plus aucun `<title>` vide

Avant:
<img width="510" height="93" alt="Capture d’écran 2026-07-27 à 12 22 41" src="https://github.com/user-attachments/assets/376719e7-b1d8-4c0d-a8c3-567bf8054348" />
 
Après:
<img width="337" height="130" alt="Capture d’écran 2026-07-27 à 12 27 07" src="https://github.com/user-attachments/assets/8ca31bf2-5f82-44f5-92c1-c780446f5e56" />


Une réserve honnête : je n'ai pas pu exercer la branche d'erreur de soumission dans mon environnement de test, faute de session phpBB fonctionnelle — le code s'arrête avant, sur `$phpbb_dispatcher`. J'ai vérifié que cet échec est identique avec et sans mon changement, mais cette branche-là n'est donc validée que par relecture.

Critères RGAA : 8.5 (titre de page), 8.6 (titre pertinent).