### PR TITLE
Légende de /nav : icônes décoratives et garde-fou sur le mapping d'icônes

### DIFF
--- a/images/icones/svg.php
+++ b/images/icones/svg.php
@@ -57,6 +57,12 @@ headers_cors_par_default();
 headers_cache_api($_GET['cache']??10000);
 // Les autres headers, notamment 404 sont générés lors de l'include
 
+// Un nom vide ou sans aucun élément reconnaissable ne remplissait ni $images ni
+// $inconnu : on sortait un SVG tronqué avec un warning au lieu du 404 prévu
+if (!isset ($images)) {
+	$inconnu = $_GET['nom'] === '' ? '(nom vide)' : $_GET['nom'];
+}
+
 if (isset ($inconnu)) {
 	header($_SERVER["SERVER_PROTOCOL"]." 404 Not Found");
 	$images = ['_404']; // Uniquement l'élément erreur 404

--- a/vues/nav.html
+++ b/vues/nav.html
@@ -38,7 +38,11 @@
           <input type="checkbox" id="select-wri" name="select-wri" value="all">
           <span id="select-wri-status"></span>
         </li>
-        <?php foreach ($vue->types_point_affichables AS $type_affichable) { ?>
+        <?php foreach ($vue->types_point_affichables AS $type_affichable) {
+          // Un type absent du mapping produisait un src vide (".svg") : on n'affiche
+          // alors pas d'icône plutôt qu'une image cassée. Même garde que point_ajout.html
+          $icone = $config_wri['correspondance_type_icone'][replace_url($type_affichable->nom_type)] ?? null;
+        ?>
           <li>
             <input type="checkbox"
               id="select-wri-<?=$type_affichable->id_point_type?>"
@@ -46,11 +50,13 @@
               value="<?=$type_affichable->id_point_type?>"
             >
             <label for="select-wri-<?=$type_affichable->id_point_type?>">
-              <img
-                id="icone_<?=$type_affichable->id_point_type?>"
-                src="<?=$config_wri['url_chemin_icones'].$config_wri['correspondance_type_icone'][replace_url($type_affichable->nom_type)]?>.svg"
-                alt="icone de <?=$type_affichable->nom_type?>"
-              >
+              <?php if ($icone) { ?>
+                <img
+                  id="icone_<?=$type_affichable->id_point_type?>"
+                  src="<?=$config_wri['url_chemin_icones'].htmlspecialchars($icone)?>.svg"
+                  alt=""
+                >
+              <?php } ?>
               <?=$type_affichable->nom_type?>
             </label>
           </li>


### PR DESCRIPTION
Bonjour ! Deux petits correctifs autour des icônes de la légende de `/nav`.

## 1. `vues/nav.html` — l'`<img>` de la légende

**Accessibilité.** L'`alt` vaut `"icone de <type>"` alors que le libellé du type est déjà en texte juste après l'image. Un lecteur d'écran annonce donc « icone de cabane non gardée, cabane non gardée ». Ce sont des icônes décoratives, `alt=""` est plus juste (RGAA 1.2).

**Robustesse.** Le mapping `correspondance_type_icone` est indexé sans garde. Un type de point présent en base mais absent de `includes/config.php` produit `src="/images/icones/.svg"`, donc une image cassée. J'ajoute la même garde que celle que vous utilisez déjà dans `point_ajout.html:20-26` (`?? null`, `<img>` conditionnel, `alt=""`, `htmlspecialchars`) — je n'ai pas voulu inventer un autre motif.

À noter : ce cas ne se manifeste pas sur www.refuges.info, où les 7 types affichés ont tous leur icône. Je l'ai rencontré en montant une copie locale avec le dump SQL public, qui contient un type `sommet` absent du mapping. Le correctif est donc préventif : il évite qu'un type ajouté un jour en base sans entrée de config casse en silence.

*(Au passage, si le dump public de `ressources/sql/` peut être régénéré, ça éviterait cette confusion aux prochains contributeurs qui montent une instance locale — il contient `sommet` mais pas `grotte`.)*

## 2. `images/icones/svg.php` — le 404 ne se déclenche pas sur un nom vide

Le générateur sait répondre 404 avec l'élément `_404` quand un élément du nom est inconnu. Mais un nom entièrement vide ne remplit ni `$images` ni `$inconnu` : on tombe alors dans le `foreach` sur une variable non définie, et on renvoie un 200 avec un SVG tronqué.

```
avant : /images/icones/.svg -> 200, SVG malformé + "Undefined variable $images"
après : /images/icones/.svg -> 404, élément _404 propre
```

`png.php` déléguant ses en-têtes à `svg.php`, il en bénéficie aussi.

## Vérifié

- les 8 icônes du site répondent 200 sans warning, et le cas « élément inconnu » garde son comportement d'origine
- légende de `/nav` : plus aucun `src` vide, rendu visuel contrôlé
- axe-core sur `/nav` : 10 règles / 59 nœuds → 9 / 58

Les `id="icone_N"` sont conservés, même s'ils ne semblent référencés nulle part (ni JS, ni CSS, ni PHP) — je préférais ne pas y toucher dans cette PR.